### PR TITLE
Add RS standard CW Alarms for Instance Recovery/Reboot

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,26 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_instance_alarm_reboo
   alarm_actions = ["arn:aws:swf:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:action/actions/AWS_EC2.InstanceId/Reboot/1.0"]
 }
 
+resource "aws_cloudwatch_metric_alarm" "status_check_failed_instance_alarm_ticket" {
+  alarm_name          = "${var.instance}-StatusCheckFailedInstanceAlarmTicket"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "10"
+  metric_name         = "StatusCheckFailed_Instance"
+  namespace           = "AWS/EC2"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "0"
+  unit                = "Count"
+  alarm_description   = "Status checks have failed, generating ticket"
+
+  dimensions {
+    InstanceId = "${var.instance}"
+  }
+
+  alarm_actions = ["arn:aws:sns:{data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency"]
+  ok_actions    = ["arn:aws:sns:{data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency"]
+}
+
 resource "aws_cloudwatch_metric_alarm" "status_check_failed_system_alarm_recover" {
   alarm_name          = "${var.instance}-StatusCheckFailedSystemAlarmRecover"
   comparison_operator = "GreaterThanThreshold"
@@ -40,4 +60,24 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_system_alarm_recover
   }
 
   alarm_actions = ["arn:aws:automate:${data.aws_region.current.name}:ec2:recover"]
+}
+
+resource "aws_cloudwatch_metric_alarm" "status_check_failed_system_alarm_ticket" {
+  alarm_name          = "${var.instance}-StatusCheckFailedSystemAlarmTicket"
+  comparison_operator = "GreaterThanThreshold"
+  evaluation_periods  = "5"
+  metric_name         = "StatusCheckFailed_System"
+  namespace           = "AWS/EC2"
+  period              = "60"
+  statistic           = "Minimum"
+  threshold           = "0"
+  unit                = "Count"
+  alarm_description   = "Status checks have failed for system, generating ticket"
+
+  dimensions {
+    InstanceId = "${var.instance}"
+  }
+
+  alarm_actions = ["arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency"]
+  ok_actions    = ["arn:aws:sns:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:rackspace-support-emergency"]
 }


### PR DESCRIPTION
Adding in the standard Rackspace ticket creation alarms for Auto Recovery instances.
These alarms are -not- optional within our CloudFormation templates, and are generated after the initial recover and reboot actions have had a chance to try and correct the system.
OK actions are present, which will update the tickets within our systems should these alarms clear.
These alarms notify Rackspace endpoints, which means these are only suitable for Aviator accounts.

This PR has been created as PR #2 hasn't been merged at present, and the related discussion isn't visible due to Issues being removed from this repository.
As such, the remove_count branch is currently in live use and so it is necessary for oversight against changes.

The remove_count branch **must not be removed** until safe to do so, and should be considered a sensitive branch at present.
Changes to remove_count are going to be reflected in future applies into customer environments as we're not tracking a tag, so we'll need to set up a new release containing these changes and then update the modules to track those release tags.