### PR TITLE
Add support for R5 and T3 instance types

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -19,7 +19,9 @@ data "aws_instances" "auto_recovery_instances" {
       "m5.*",
       "r3.*",
       "r4.*",
+      "r5.*",
       "t2.*",
+      "t3.*",
       "x1.*",
     ]
   }

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ data "aws_instances" "auto_recovery_instances" {
       "t2.*",
       "t3.*",
       "x1.*",
+      "x1e.*",
     ]
   }
 


### PR DESCRIPTION
R5 and T3 instances support autorecovery but are not listed, which causes new R5 instances to have autorecovery removed when they are upgraded to the new instance types. 