### PR TITLE
Ensure valid datapoints_to_alarm value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,7 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_instance_alarm_reboo
   period              = "${var.failed_instance_checks_period}"
   statistic           = "Minimum"
   threshold           = "0"
+  datapoints_to_alarm = "1"
   unit                = "Count"
 
   dimensions {
@@ -77,6 +78,7 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_instance_alarm_ticke
   period              = "${var.failed_instance_checks_period}"
   statistic           = "Minimum"
   threshold           = "0"
+  datapoints_to_alarm = "1"
   unit                = "Count"
 
   dimensions {
@@ -97,6 +99,7 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_system_alarm_recover
   period              = "${var.failed_system_checks_period}"
   statistic           = "Minimum"
   threshold           = "0"
+  datapoints_to_alarm = "1"
   unit                = "Count"
 
   dimensions {
@@ -118,6 +121,7 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_system_alarm_ticket"
   period              = "${var.failed_system_checks_period}"
   statistic           = "Minimum"
   threshold           = "0"
+  datapoints_to_alarm = "1"
   unit                = "Count"
 
   dimensions {


### PR DESCRIPTION
We're seeing AWS reject requests for this:
```
datapoints_to_alarm:      "0"
```

It turns out it must be >= 1, and when omitted, CloudWatch Alarms does the right thing, but Terraform wants to default this to "0" still:

https://github.com/terraform-providers/terraform-provider-aws/issues/4350 (problem report)
https://github.com/terraform-providers/terraform-provider-aws/pull/5095 (validation to 1)

AWS API docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_PutMetricAlarm.html