### PR TITLE
Datapoints to alarm should be 5

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -56,7 +56,7 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_instance_alarm_reboo
   period              = "${var.failed_instance_checks_period}"
   statistic           = "Minimum"
   threshold           = "0"
-  datapoints_to_alarm = "1"
+  datapoints_to_alarm = "5"
   unit                = "Count"
 
   dimensions {
@@ -78,7 +78,7 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_instance_alarm_ticke
   period              = "${var.failed_instance_checks_period}"
   statistic           = "Minimum"
   threshold           = "0"
-  datapoints_to_alarm = "1"
+  datapoints_to_alarm = "5"
   unit                = "Count"
 
   dimensions {
@@ -99,7 +99,7 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_system_alarm_recover
   period              = "${var.failed_system_checks_period}"
   statistic           = "Minimum"
   threshold           = "0"
-  datapoints_to_alarm = "1"
+  datapoints_to_alarm = "5"
   unit                = "Count"
 
   dimensions {
@@ -121,7 +121,7 @@ resource "aws_cloudwatch_metric_alarm" "status_check_failed_system_alarm_ticket"
   period              = "${var.failed_system_checks_period}"
   statistic           = "Minimum"
   threshold           = "0"
-  datapoints_to_alarm = "1"
+  datapoints_to_alarm = "5"
   unit                = "Count"
 
   dimensions {


### PR DESCRIPTION
5 observations in 5 minutes is our typical threshold. It seems that Terraform defaulted it to 0 in the state file, and AWS defaulted it to 5 in the UI -- so this sets it to the correct number.